### PR TITLE
Update code so that truncated images will load

### DIFF
--- a/data/unaligned_triplet_dataset.py
+++ b/data/unaligned_triplet_dataset.py
@@ -5,6 +5,8 @@ from data.image_folder import make_dataset
 from PIL import Image
 import PIL
 import random
+from PIL import ImageFile
+ImageFile.LOAD_TRUNCATED_IMAGES = True
 
 
 class UnalignedTripletDataset(BaseDataset):


### PR DESCRIPTION
Update code so that truncated images will load instead of crashing the program.
The Oliver/Colbert dataset referenced by readme contains truncated images (whatever that means).